### PR TITLE
Bugfix for when no matching agents found

### DIFF
--- a/example/lib/zendesk_chat.dart
+++ b/example/lib/zendesk_chat.dart
@@ -6,6 +6,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:zendesk2/chat2/model/provider_model.dart';
 import 'package:zendesk2/zendesk2.dart';
+import 'package:collection/collection.dart';
 
 class ZendeskChat extends StatefulWidget {
   _ZendeskChat createState() => _ZendeskChat();
@@ -274,7 +275,7 @@ class _ZendeskChat extends State<ZendeskChat> {
           Agent? agent;
           if (isAgent)
             agent = _providerModel!.agents
-                .firstWhere((element) => element.displayName == name);
+                .firstWhereOrNull((element) => element.displayName == name);
 
           switch (log.chatLogType.logType) {
             case LOG_TYPE.ATTACHMENT_MESSAGE:


### PR DESCRIPTION
When ending chat, error given is "Bad state: No element" when no matching agent is found. Null needs to be returned in this case.