### PR TITLE
fix(jcentral): Remove reference to jCenter (1.6)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.4.21'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
     }
 
@@ -18,7 +18,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zendesk2
 description: Zendesk Android and iOS SDK port for Flutter, easily open native chat or manipulate providers for custom UI
-version: 1.6.2+0
+version: 1.6.2+1
 homepage: https://github.com/KohlsAdrian/zendesk2
 
 environment:


### PR DESCRIPTION
jCenter is unreachable, switching to mavenCentral

This is for a 1.6.x release.